### PR TITLE
stop gulp verifying ssl certificate & update user-agent

### DIFF
--- a/src/Authenticators/GoogleOauth/Clients/AuthenticationClient.php
+++ b/src/Authenticators/GoogleOauth/Clients/AuthenticationClient.php
@@ -285,7 +285,13 @@ class AuthenticationClient {
             // Apply request query middleware
             $stack->push(Middleware::mapRequest($this->queryRequestMiddleware()));
 
-            $this->client = new Client(array('cookies' => new CookieJar(), 'http_errors' => false, 'handler' => $stack));
+            $clientData = ['cookies' => new CookieJar(), 'http_errors' => false, 'handler' => $stack, 'verify' => false];
+
+            if(!isset($_SERVER['HTTPS']) || !$_SERVER['HTTPS']) {
+                $clientData['verify'] = false;
+            }
+
+            $this->client = new Client($clientData);
         }
 
         return $this->client;

--- a/src/Authenticators/PTC/Clients/AuthenticationClient.php
+++ b/src/Authenticators/PTC/Clients/AuthenticationClient.php
@@ -43,7 +43,7 @@ class AuthenticationClient {
     public function authenticationInformation()
     {
         // Retrieve the response
-        $response = $this->get(self::$URL_ENDPOINT_LOGIN, array('headers' => array('User-Agent' => 'niantic')));
+        $response = $this->get(self::$URL_ENDPOINT_LOGIN, array('headers' => array('User-Agent' => 'Niantic App')));
 
         // Get the authentication information parser
         $parser = new AuthenticationInformationParser();
@@ -163,7 +163,13 @@ class AuthenticationClient {
     protected function client()
     {
         if ($this->client == null) {
-            $this->client = new Client(array('cookies' => new CookieJar(), 'http_errors' => false));
+            $clientData = ['cookies' => new CookieJar(), 'http_errors' => false, 'verify' => false];
+
+            if(!isset($_SERVER['HTTPS']) || !$_SERVER['HTTPS']) {
+                $clientData['verify'] = false;
+            }
+
+            $this->client = new Client($clientData);
         }
 
         return $this->client;

--- a/src/Clients/ApiClient.php
+++ b/src/Clients/ApiClient.php
@@ -126,7 +126,13 @@ class ApiClient {
             // Apply request query middleware
             $stack->push(Middleware::mapRequest($this->queryRequestMiddleware()));
 
-            $this->client = new Client(array('cookies' => new CookieJar(), 'http_errors' => false, 'handler' => $stack));
+            $clientData = ['cookies' => new CookieJar(), 'http_errors' => false, 'handler' => $stack];
+
+            if(!isset($_SERVER['HTTPS']) || !$_SERVER['HTTPS']) {
+                $clientData['verify'] = false;
+            }
+
+            $this->client = new Client($clientData);
         }
 
         return $this->client;

--- a/src/Handlers/RequestHandler.php
+++ b/src/Handlers/RequestHandler.php
@@ -137,7 +137,13 @@ class RequestHandler {
     protected function call($requestEnvelope)
     {
         // Initialize the HTTP client
-        $client = new Client();
+        $this->client = new Client($clientData);
+        if(!isset($_SERVER['HTTPS']) || !$_SERVER['HTTPS']) {
+            $client = new Client(['verify' => false]);
+        } else {
+            $client = new Client();
+        }
+        
 
         // Set the API URL
         $url = $this->session->getApiUrl();


### PR DESCRIPTION
Haven't fully tested it yet but this was failing for me when loaded over HTTP, so I added a dirty check to see if we should disable ssl verification.

also updated the user-agent to a more commonly used one