### PR TITLE
Use StreamWrapper to pass resource

### DIFF
--- a/src/Handlers/RequestHandler.php
+++ b/src/Handlers/RequestHandler.php
@@ -5,6 +5,7 @@ namespace NicklasW\PkmGoApi\Handlers;
 use Exception;
 use GuzzleHttp\Client;
 use GuzzleHttp\Psr7\Request as HttpRequest;
+use GuzzleHttp\Psr7\StreamWrapper;
 use NicklasW\PkmGoApi\Facades\Log;
 use NicklasW\PkmGoApi\Handlers\RequestHandler\Exceptions\AuthenticationException;
 use NicklasW\PkmGoApi\Handlers\RequestHandler\Exceptions\ResponseException;
@@ -230,7 +231,7 @@ class RequestHandler {
         $responseEnvelop = new ResponseEnvelope();
 
         // Unmarshall the response
-        $responseEnvelop->read($response->getBody()->getContents());
+        $responseEnvelop->read(StreamWrapper::getResource($response->getBody()));
 
         return $responseEnvelop;
     }


### PR DESCRIPTION
`\ProtobufIO::toStream` [converts the content back to a resource anyways if a string is passed](https://github.com/NicklasWallgren/pogoprotos-php/blob/bfb3fce41ff37e8a39e115a20de2c838f3f70d38/src/protocolbuffers.inc.php#L46-L52).

I had to learn this one aswell :laughing: : DrDelay/pokemon-go#3