### PR TITLE
Basic implementation of Google OAuth via authorization code

### DIFF
--- a/src/Authenticators/Factory.php
+++ b/src/Authenticators/Factory.php
@@ -87,4 +87,5 @@ class Factory {
     {
         return new GoogleOAuthAuthenticator();
     }
+
 }

--- a/src/Authenticators/Factory.php
+++ b/src/Authenticators/Factory.php
@@ -18,6 +18,8 @@ class Factory {
      */
     const AUTHENTICATION_TYPE_PTC = '2';
 
+    const AUTHENTICATION_TYPE_GOOGLE_OAUTH = 3;
+
     /**
      * Authenticator factory.
      *
@@ -38,6 +40,11 @@ class Factory {
 
             case self::AUTHENTICATION_TYPE_PTC:
                 $authenticator = $this->createPTCAuthenticator();
+
+                break;
+
+            case self::AUTHENTICATION_TYPE_GOOGLE_OAUTH:
+                $authenticator = $this->createGoogleOAuthAuthenticator();
 
                 break;
 
@@ -71,5 +78,13 @@ class Factory {
         return new PTCAuthenticator();
     }
 
-
+    /**
+     * Creates a GoogleOAuth Authenticator.
+     *
+     * @return GoogleOAuthAuthenticator
+     */
+    protected function createGoogleOAuthAuthenticator()
+    {
+        return new GoogleOAuthAuthenticator();
+    }
 }

--- a/src/Authenticators/GoogleAuthCode/Clients/AuthenticationClient.php
+++ b/src/Authenticators/GoogleAuthCode/Clients/AuthenticationClient.php
@@ -1,0 +1,75 @@
+<?php
+
+/**
+ * @author DrDelay <info@vi0lation.de>
+ */
+
+namespace NicklasW\PkmGoApi\Authenticators\GoogleAuthCode\Clients;
+
+use NicklasW\PkmGoApi\Authenticators\GoogleAuthCode\Parsers\GoogleOAuthParser;
+use NicklasW\PkmGoApi\Clients\Client;
+
+class AuthenticationClient
+{
+    const GOOGLE_OAUTH_TOKEN_URL = 'https://www.googleapis.com/oauth2/v4/token';
+    const GOOGLE_OAUTH_CLIENT_ID = '848232511240-73ri3t7plvk96pj4f85uj8otdat2alem.apps.googleusercontent.com';
+    const GOOGLE_OAUTH_CLIENT_SECRET = 'NCjF1TLi2CcY6t5mt0ZveuL7';
+    const SCOPE = 'openid email https://www.googleapis.com/auth/userinfo.email';
+    const REDIRECT = 'urn:ietf:wg:oauth:2.0:oob';
+
+    /**
+     * @var Client|null
+     */
+    protected $client;
+
+    /**
+     * Retrieve the oauth token and refresh_token by auth-code.
+     *
+     * @param string $authorization_code
+     *
+     * @return \NicklasW\PkmGoApi\Authenticators\GoogleAuthCode\Parsers\Results\GoogleOAuthResult
+     */
+    public function exchangeAuthCode($authorization_code)
+    {
+        return GoogleOAuthParser::parse($this->client()->post(static::GOOGLE_OAUTH_TOKEN_URL, ['form_params' => [
+            'code' => $authorization_code,
+            'client_id' => static::GOOGLE_OAUTH_CLIENT_ID,
+            'client_secret' => static::GOOGLE_OAUTH_CLIENT_SECRET,
+            'grant_type' => 'authorization_code',
+            'redirect_uri' => static::REDIRECT,
+        ]]));
+    }
+
+    /**
+     * Retrieve the oauth token by refresh_token.
+     *
+     * @param string $refreshToken
+     *
+     * @return \NicklasW\PkmGoApi\Authenticators\GoogleAuthCode\Parsers\Results\GoogleOAuthResult
+     */
+    public function getOauthToken($refreshToken)
+    {
+        return GoogleOAuthParser::parse($this->client()->post(static::GOOGLE_OAUTH_TOKEN_URL, ['form_params' => [
+            'access_type' => 'offline',
+            'client_id' => static::GOOGLE_OAUTH_CLIENT_ID,
+            'client_secret' => static::GOOGLE_OAUTH_CLIENT_SECRET,
+            'refresh_token' => $refreshToken,
+            'grant_type' => 'refresh_token',
+            'scope' => static::SCOPE,
+        ]]));
+    }
+
+    /**
+     * Returns the Client.
+     *
+     * @return Client
+     */
+    protected function client()
+    {
+        if (!$this->client) {
+            $this->client = new Client(['cookies' => true]);
+        }
+
+        return $this->client;
+    }
+}

--- a/src/Authenticators/GoogleAuthCode/Parsers/GoogleOAuthParser.php
+++ b/src/Authenticators/GoogleAuthCode/Parsers/GoogleOAuthParser.php
@@ -1,0 +1,42 @@
+<?php
+
+/**
+ * @author DrDelay <info@vi0lation.de>
+ */
+
+namespace NicklasW\PkmGoApi\Authenticators\GoogleAuthCode\Parsers;
+
+use NicklasW\PkmGoApi\Authenticators\Exceptions\AuthenticationException;
+use NicklasW\PkmGoApi\Authenticators\Exceptions\ResponseException;
+use NicklasW\PkmGoApi\Authenticators\GoogleAuthCode\Parsers\Results\GoogleOAuthResult;
+use Psr\Http\Message\ResponseInterface;
+use function GuzzleHttp\json_decode;
+
+class GoogleOAuthParser
+{
+    /**
+     * Parses a Google OAuth response.
+     *
+     * @param ResponseInterface $response
+     *
+     * @return GoogleOAuthResult
+     *
+     * @throws AuthenticationException
+     * @throws ResponseException
+     */
+    public static function parse(ResponseInterface $response)
+    {
+        $data = json_decode($response->getBody());
+        $status = $response->getStatusCode();
+
+        if ($status != 200) {
+            throw new AuthenticationException(isset($data->error_description) ? $data->error_description : 'Auth failed', $status);
+        }
+
+        if (!(isset($data->id_token) && isset($data->expires_in))) {
+            throw new ResponseException('Incomplete response from Google');
+        }
+
+        return new GoogleOAuthResult($data->id_token, (int) $data->expires_in, isset($data->refresh_token) ? $data->refresh_token : null);
+    }
+}

--- a/src/Authenticators/GoogleAuthCode/Parsers/Results/GoogleOAuthResult.php
+++ b/src/Authenticators/GoogleAuthCode/Parsers/Results/GoogleOAuthResult.php
@@ -1,0 +1,63 @@
+<?php
+
+/**
+ * @author DrDelay <info@vi0lation.de>
+ */
+
+namespace NicklasW\PkmGoApi\Authenticators\GoogleAuthCode\Parsers\Results;
+
+class GoogleOAuthResult
+{
+    /** @var string|null */
+    protected $refresh_token;
+
+    /** @var string */
+    protected $id_token;
+
+    /** @var int */
+    protected $expires_in;
+
+    /**
+     * GoogleOAuthResult constructor.
+     *
+     * @param string      $id_token
+     * @param int         $expires_in
+     * @param string|null $refresh_token
+     */
+    public function __construct($id_token, $expires_in, $refresh_token = null)
+    {
+        $this->id_token = $id_token;
+        $this->expires_in = $expires_in;
+        $this->refresh_token = $refresh_token;
+    }
+
+    /**
+     * Returns the refresh token.
+     *
+     * @return null|string
+     */
+    public function getRefreshToken()
+    {
+        return $this->refresh_token;
+    }
+
+    /**
+     * Returns the id token.
+     *
+     * @return string
+     */
+    public function getIdToken()
+    {
+        return $this->id_token;
+    }
+
+    /**
+     * Returns the lifetime.
+     *
+     * @return int
+     */
+    public function getExpiresIn()
+    {
+        return $this->expires_in;
+    }
+}

--- a/src/Authenticators/GoogleOAuthAuthenticator.php
+++ b/src/Authenticators/GoogleOAuthAuthenticator.php
@@ -1,0 +1,82 @@
+<?php
+
+/**
+ * @author DrDelay <info@vi0lation.de>
+ */
+
+namespace NicklasW\PkmGoApi\Authenticators;
+
+use NicklasW\PkmGoApi\Authenticators\Contracts\Authenticator;
+use NicklasW\PkmGoApi\Authenticators\GoogleAuthCode\Clients\AuthenticationClient;
+use NicklasW\PkmGoApi\Facades\Log;
+
+class GoogleOAuthAuthenticator implements Authenticator
+{
+    /**
+     * @var AuthenticationClient|null
+     */
+    protected $authenticationClient;
+
+    public function login($identifier, $authorization_code)
+    {
+        $oauthToken = null;
+
+        $cacheHit = false; // TODO: Add caching of refresh token
+        if ($cacheHit) {
+            $oauthToken = $this->getOauthToken('refresh_token from cache'); // TODO
+        } else {
+            $oauthToken = $this->exchangeAuthCode($authorization_code);
+            $refreshToken = $oauthToken->getRefreshToken(); // TODO: Save to cache
+            Log::debug(sprintf('[#%s] Refresh_token: \'%s\'', __CLASS__, $refreshToken));
+        }
+
+        $idToken = $oauthToken->getIdToken();
+
+        Log::debug(sprintf('[#%s] OAuth token: \'%s\'', __CLASS__, $idToken));
+
+        return $idToken;
+    }
+
+    public function identifier()
+    {
+        return 'google';
+    }
+
+    /**
+     * Retrieve the oauth token and refresh_token by auth-code.
+     *
+     * @param string $authorization_code
+     *
+     * @return \NicklasW\PkmGoApi\Authenticators\GoogleAuthCode\Parsers\Results\GoogleOAuthResult
+     */
+    public function exchangeAuthCode($authorization_code)
+    {
+        return $this->client()->exchangeAuthCode($authorization_code);
+    }
+
+    /**
+     * Retrieve the oauth token by refresh_token.
+     *
+     * @param string $refreshToken
+     *
+     * @return \NicklasW\PkmGoApi\Authenticators\GoogleAuthCode\Parsers\Results\GoogleOAuthResult
+     */
+    public function getOauthToken($refreshToken)
+    {
+        return $this->client()->getOauthToken($refreshToken);
+    }
+
+    /**
+     * Returns the Authentication client.
+     *
+     * @return AuthenticationClient
+     */
+    protected function client()
+    {
+        if (!$this->authenticationClient) {
+            $this->authenticationClient = new AuthenticationClient();
+        }
+
+        return $this->authenticationClient;
+    }
+}

--- a/src/Authenticators/GoogleOAuthAuthenticator.php
+++ b/src/Authenticators/GoogleOAuthAuthenticator.php
@@ -49,7 +49,7 @@ class GoogleOAuthAuthenticator implements Authenticator
      *
      * @return \NicklasW\PkmGoApi\Authenticators\GoogleAuthCode\Parsers\Results\GoogleOAuthResult
      */
-    public function exchangeAuthCode($authorization_code)
+    protected function exchangeAuthCode($authorization_code)
     {
         return $this->client()->exchangeAuthCode($authorization_code);
     }
@@ -61,7 +61,7 @@ class GoogleOAuthAuthenticator implements Authenticator
      *
      * @return \NicklasW\PkmGoApi\Authenticators\GoogleAuthCode\Parsers\Results\GoogleOAuthResult
      */
-    public function getOauthToken($refreshToken)
+    protected function getOauthToken($refreshToken)
     {
         return $this->client()->getOauthToken($refreshToken);
     }


### PR DESCRIPTION
Regarding #39 and #52 , this lets users use do:
``` php
$application = new ApplicationKernel('CanBeGoogleEmailDoesntHaveToBe', 'AuthorizationCode', Factory::AUTHENTICATION_TYPE_GOOGLE_OAUTH);
```
The first parameter could in the future be used to cache the *refresh_token*. It is not relevant however as long as the **authorization code** is valid. It can be obtained here: https://accounts.google.com/o/oauth2/auth?client_id=848232511240-73ri3t7plvk96pj4f85uj8otdat2alem.apps.googleusercontent.com&redirect_uri=urn%3Aietf%3Awg%3Aoauth%3A2.0%3Aoob&response_type=code&scope=openid%20email%20https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fuserinfo.email&approval_prompt=force