### PR TITLE
Fix wrong comparison timestamp

### DIFF
--- a/src/Authentication/AccessToken.php
+++ b/src/Authentication/AccessToken.php
@@ -99,7 +99,7 @@ class AccessToken {
      */
     public function isTimestampValid()
     {
-        return $this->hasTimestamp() && intval($this->timestamp) > microtime();
+        return $this->hasTimestamp() && intval($this->timestamp) > time();
     }
 
     /**


### PR DESCRIPTION
As mentioned [here](https://github.com/NicklasWallgren/PokemonGoAPI-PHP/commit/7274f68cd73cbd7144de4a36a158f09fa2b2024b#commitcomment-18577835)