### PR TITLE
Added createAuthenticationManagerByAccessToken functionality with PTC

### DIFF
--- a/src/Authentication/Managers/PTC/AuthenticationOauthTokenManager.php
+++ b/src/Authentication/Managers/PTC/AuthenticationOauthTokenManager.php
@@ -1,0 +1,43 @@
+<?php
+
+/**
+ * @author DrDelay <info@vi0lation.de>
+ */
+
+namespace NicklasW\PkmGoApi\Authentication\Managers\PTC;
+
+use NicklasW\PkmGoApi\Authentication\AccessToken;
+use NicklasW\PkmGoApi\Authentication\Factory\Factory;
+use NicklasW\PkmGoApi\Authentication\Manager;
+
+class AuthenticationOauthTokenManager extends Manager
+{
+    /** @var string */
+    protected $token;
+
+    /**
+     * AuthenticationOauthTokenManager constructor.
+     *
+     * @param string $token
+     */
+    public function __construct($token)
+    {
+        $this->token = $token;
+    }
+
+    public function getAccessToken()
+    {
+        $accessToken = new AccessToken($this->token, AccessToken::PROVIDER_PTC);
+
+        $this->dispatchEvent(static::EVENT_ACCESS_TOKEN, $accessToken);
+
+        $this->setAccessToken($accessToken);
+
+        return $accessToken;
+    }
+
+    public function getIdentifier()
+    {
+        return Factory::PROVIDER_PTC;
+    }
+}


### PR DESCRIPTION
This adds the *PTCAuthenticationOauthTokenManager* analog to the existing Google one and differs in the `createAuthenticationManagerByAccessToken`-method between AccessToken-types.

This now works:
``` php
$ptcToken = new AccessToken('TGT-4171161-0R.......MXR-sso.pokemon.com', AccessToken::PROVIDER_PTC, 1470774637);
$manager = Factory::create($ptcToken);
$application = new ApplicationKernel($manager);
// ...
```