### PR TITLE
Improved AccessToken handling in "ManagerByToken-case"

### DIFF
--- a/src/Authentication/Factory/Factory.php
+++ b/src/Authentication/Factory/Factory.php
@@ -72,7 +72,7 @@ class Factory {
         if ($accessToken->getProvider() == AccessToken::PROVIDER_GOOGLE) {
             // Check if a token timestamp is provided
             if (!$accessToken->hasTimestamp()) {
-                return new GoogleAuthenticationOauthTokenManager($accessToken->getToken());
+                return new GoogleAuthenticationOauthTokenManager($accessToken);
             }
 
             // Check if a fresh token is available, check if it is still valid
@@ -81,7 +81,7 @@ class Factory {
             }
 
             if ($accessToken->isTimestampValid()) {
-                return new GoogleAuthenticationOauthTokenManager($accessToken->getToken());
+                return new GoogleAuthenticationOauthTokenManager($accessToken);
             }
 
             throw new AuthenticationException('Please re-login, the access token has expired');
@@ -90,7 +90,7 @@ class Factory {
                 throw new AuthenticationException('Please re-login, the access token has expired');
             }
 
-            return new PTCAuthenticationOauthTokenManager($accessToken->getToken());
+            return new PTCAuthenticationOauthTokenManager($accessToken);
         }
 
         throw new Exception('Invalid config provided. No provider defined');

--- a/src/Authentication/Managers/Google/AuthenticationOauthTokenManager.php
+++ b/src/Authentication/Managers/Google/AuthenticationOauthTokenManager.php
@@ -15,11 +15,15 @@ class AuthenticationOauthTokenManager extends Manager {
     /**
      * AuthenticationOauthTokenManager constructor.
      *
-     * @param string $token
+     * @param AccessToken|string $token
      */
     public function __construct($token)
     {
-        $this->token = $token;
+        if ($token instanceof AccessToken) {
+            $this->setAccessToken($token);
+        } else {
+            $this->token = $token;
+        }
     }
 
     /**
@@ -29,15 +33,14 @@ class AuthenticationOauthTokenManager extends Manager {
      */
     public function getAccessToken()
     {
-        $accessToken = new AccessToken($this->token, AccessToken::PROVIDER_GOOGLE);
+        if (!$this->accessToken) {
+            $this->accessToken = new AccessToken($this->token, AccessToken::PROVIDER_GOOGLE);
+        }
 
         // Dispatch event to listeners
-        $this->dispatchEvent(static::EVENT_ACCESS_TOKEN, $accessToken);
+        $this->dispatchEvent(static::EVENT_ACCESS_TOKEN, $this->accessToken);
 
-        // Add the access token to the manager
-        $this->setAccessToken($accessToken);
-
-        return $accessToken;
+        return $this->accessToken;
     }
 
     /**

--- a/src/Authentication/Managers/PTC/AuthenticationOauthTokenManager.php
+++ b/src/Authentication/Managers/PTC/AuthenticationOauthTokenManager.php
@@ -12,28 +12,21 @@ use NicklasW\PkmGoApi\Authentication\Manager;
 
 class AuthenticationOauthTokenManager extends Manager
 {
-    /** @var string */
-    protected $token;
-
     /**
      * AuthenticationOauthTokenManager constructor.
      *
-     * @param string $token
+     * @param AccessToken $token
      */
-    public function __construct($token)
+    public function __construct(AccessToken $token)
     {
-        $this->token = $token;
+        $this->setAccessToken($token);
     }
 
     public function getAccessToken()
     {
-        $accessToken = new AccessToken($this->token, AccessToken::PROVIDER_PTC);
+        $this->dispatchEvent(static::EVENT_ACCESS_TOKEN, $this->accessToken);
 
-        $this->dispatchEvent(static::EVENT_ACCESS_TOKEN, $accessToken);
-
-        $this->setAccessToken($accessToken);
-
-        return $accessToken;
+        return $this->accessToken;
     }
 
     public function getIdentifier()


### PR DESCRIPTION
- No longer "loses" timestamp information
- Don't re-instantiate it with the exact same data if the user provides one

The main thing that bothered me was that if I passed a token with a timestamp the listeners received a *EVENT_ACCESS_TOKEN* with a token that no longer had that timestamp. So people that save the token whenever they receive the event (what is reasonable; but it might also be worth a discussion whether the event has to be fired at all with the exact same token as provided) would have lost this information.