### PR TITLE
Install via composer repository guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,15 @@
 # PokemonGoAPI-PHP
 Pokemon GO PHP API library
 
-# Build
-  - Clone the repo and cd into the folder
-  - `` git clone <repo> ``
-  - Install the dependencies
-  - `` composer install ``
+# Install
+Add the following properties to your project's `composer.json` file:
+
+```json
+"minimum-stability": "dev",
+"prefer-stable": true
+```
+
+Then run the command `composer require nicklasw/pkm-go-api`.
 
 # Usage
 EG:


### PR DESCRIPTION
Just change the "Build" heading the the README.md to "Install" with instruction on how to install as a composer package without being on Packagist. I believe most devs who are willing to work on this package would know how to "Build" the app although some may be unaware how to install as a package without it being on Packagist.