### PR TITLE
Refactor authentication managers to expose config object and add default .env file location

### DIFF
--- a/examples/AuthenticationExample.php
+++ b/examples/AuthenticationExample.php
@@ -35,6 +35,20 @@ class AuthenticationExample {
         // Create the authentication manager
         $manager = Factory::create($config);
 
+
+        // EXAMPLE Authentication via Google user credentials
+        // with custom environment file path
+        $config = new Config();
+        $config->setProvider(Factory::PROVIDER_GOOGLE);
+        $config->setUser('INSERT_EMAIL');
+        $config->setPassword('INSERT_PASSWORD');
+        $config->setEnvFilePath('PATH_TO_FILE');
+
+        // Create the authentication manager
+        $manager = Factory::create($config);
+
+
+
         // EXAMPLE Authentication via Google authentication code
         $config = new Config();
         $config->setProvider(Factory::PROVIDER_GOOGLE);
@@ -60,6 +74,13 @@ class AuthenticationExample {
 
         // Initialize the pokemon go application
         $application = new ApplicationKernel($manager);
+
+        // Initialize the pokemon go application
+        // with custom environment file path
+        $application = new ApplicationKernel($manager, 'PATH_TO_FILE');
+
+        // NOTE: the custom environment file path passed to the ApplicationKernel
+        // will override the setEnvFilePath() method of the Config object.
     }
 
 }

--- a/includes/config.php
+++ b/includes/config.php
@@ -43,3 +43,31 @@ if (!function_exists('env')) {
         return $value;
     }
 }
+
+
+if (!function_exists("searchEnvFilePath")) {
+    /**
+     * Do an upward directory scan to check if an environment file exists
+     *
+     * @param string $filename
+     * @param int $depth
+     * @return null|string
+     */
+    function searchEnvFilePath($filename = ".env", $depth = 4)
+    {
+
+        $pwd = getcwd();
+
+        $max_depth = realpath('.' . str_repeat('/..', $depth));
+
+        while (($pwd = realpath("{$pwd}/..")) != $max_depth) {
+
+            if (file_exists("{$pwd}/{$filename}")) {
+
+                return $pwd;
+
+            }
+        }
+        return null;
+    }
+}

--- a/src/Authentication/Config/AccessTokenConfig.php
+++ b/src/Authentication/Config/AccessTokenConfig.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace NicklasW\PkmGoApi\Authentication\Config;
+
+use NicklasW\PkmGoApi\Authentication\AccessToken;
+
+class AccessTokenConfig extends AccessToken{
+
+
+    /**
+     * @var string
+     */
+    protected $env_file_path;
+
+
+
+    public function __construct(AccessToken $accessToken)
+    {
+        $this->setAccessToken($accessToken);
+    }
+
+    public function setAccessToken(AccessToken $accessToken)
+    {
+
+        $this->token            = $accessToken->getToken();
+        $this->provider         = $accessToken->getProvider();
+        $this->timestamp        = $accessToken->getTimestamp();
+        $this->refreshToken     = $accessToken->getRefreshToken();
+
+    }
+
+
+    /**
+     * @return string
+     */
+    public function getEnvFilePath()
+    {
+
+        // attempt to resolve environment file by looking up the parent directories
+        // the default depth limit is 4
+        if ($this->env_file_path === null) {
+
+            $this->env_file_path = searchEnvFilePath();
+
+        }
+
+        return $this->env_file_path;
+    }
+
+    /**
+     * @return string
+     */
+    public function setEnvFilePath($path)
+    {
+        $this->env_file_path = $path;
+    }
+
+
+}

--- a/src/Authentication/Config/Config.php
+++ b/src/Authentication/Config/Config.php
@@ -38,6 +38,11 @@ class Config {
     protected $provider;
 
     /**
+     * @var string
+     */
+    protected $env_file_path;
+
+    /**
      * Converts the access token to a config object.
      *
      * @param AccessToken $accessToken
@@ -49,6 +54,32 @@ class Config {
 
 
 
+    }
+
+
+    /**
+     * @return string
+     */
+    public function getEnvFilePath()
+    {
+
+        // attempt to resolve environment file by looking up the parent directories
+        // the default depth limit is 4
+        if ($this->env_file_path === null) {
+
+            $this->env_file_path = searchEnvFilePath();
+
+        }
+
+        return $this->env_file_path;
+    }
+
+    /**
+     * @return string
+     */
+    public function setEnvFilePath($path)
+    {
+        $this->env_file_path = $path;
     }
 
     /**

--- a/src/Authentication/Factory/Factory.php
+++ b/src/Authentication/Factory/Factory.php
@@ -77,7 +77,7 @@ class Factory {
 
             // Check if a fresh token is available, check if it is still valid
             if ($accessToken->hasFreshToken() && $accessToken->isTimestampValid()) {
-                return new GoogleAuthenticationRefreshTokenManager($accessToken->getRefreshToken());
+                return new GoogleAuthenticationRefreshTokenManager($accessToken);
             }
 
             if ($accessToken->isTimestampValid()) {
@@ -135,7 +135,7 @@ class Factory {
     protected static function createPTCManager($config)
     {
         if (self::isAdaptedForUserCredentialsManager($config)) {
-            return new PTCAuthenticationCredentialsManager($config->getUser(), $config->getPassword());
+            return new PTCAuthenticationCredentialsManager($config);
         }
 
         throw new AuthenticationException('Invalid config provided. Could not create authentication manager');
@@ -204,7 +204,7 @@ class Factory {
      */
     protected static function createGoogleRefreshTokenManager($config)
     {
-        return new GoogleAuthenticationRefreshTokenManager($config->getRefreshToken());
+        return new GoogleAuthenticationRefreshTokenManager($config);
     }
 
     /**
@@ -215,7 +215,7 @@ class Factory {
      */
     protected static function createGoogleOauthManager($config)
     {
-        return new GoogleAuthenticationOauthTokenManager($config->getOauthToken());
+        return new GoogleAuthenticationOauthTokenManager($config);
     }
 
     /**
@@ -226,7 +226,7 @@ class Factory {
      */
     protected static function createGoogleAuthenticationCodeManager($config)
     {
-        return new GoogleAuthenticationCodeManager($config->getAuthToken());
+        return new GoogleAuthenticationCodeManager($config);
     }
 
     /**
@@ -237,7 +237,7 @@ class Factory {
      */
     protected static function createGoogleUserCredentialsManager($config)
     {
-        return new GoogleAuthenticationCredentialsManager($config->getUser(), $config->getPassword());
+        return new GoogleAuthenticationCredentialsManager($config);
     }
 
 }

--- a/src/Authentication/Manager.php
+++ b/src/Authentication/Manager.php
@@ -3,6 +3,8 @@
 namespace NicklasW\PkmGoApi\Authentication;
 
 use Closure;
+use NicklasW\PkmGoApi\Authentication\Config\Config;
+use NicklasW\PkmGoApi\Authentication\Exceptions\AuthenticationException;
 
 abstract class Manager {
 
@@ -20,6 +22,28 @@ abstract class Manager {
      * @var AccessToken The access token
      */
     protected $accessToken;
+
+    /**
+     * @var Config
+     */
+    protected $config;
+
+    public function __construct($config)
+    {
+        $this->config = $config;
+    }
+
+
+    /**
+     * Returns the Config Object
+     *
+     * @return Config
+     */
+    public function getConfig()
+    {
+        return $this->config;
+    }
+
 
     /**
      * Returns the Oauth token.

--- a/src/Authentication/Managers/Google/AuthenticationCodeManager.php
+++ b/src/Authentication/Managers/Google/AuthenticationCodeManager.php
@@ -15,11 +15,13 @@ class AuthenticationCodeManager extends Manager {
     /**
      * AuthenticationCodeManager constructor.
      *
-     * @param string $authenticationCode
+     * @param $config
      */
-    public function __construct($authenticationCode)
+    public function __construct($config)
     {
-        $this->authenticationCode = $authenticationCode;
+        parent::__construct($config);
+
+        $this->authenticationCode = $config->getAuthToken();
     }
 
     /**

--- a/src/Authentication/Managers/Google/AuthenticationCredentialsManager.php
+++ b/src/Authentication/Managers/Google/AuthenticationCredentialsManager.php
@@ -21,13 +21,14 @@ class AuthenticationCredentialsManager extends Manager {
     /**
      * AuthenticationCredentialsManager constructor.
      *
-     * @param string $email
-     * @param string $password
+     * @param $config
      */
-    public function __construct($email, $password)
+    public function __construct($config)
     {
-        $this->email = $email;
-        $this->password = $password;
+        parent::__construct($config);
+
+        $this->email    = $config->getUser();
+        $this->password = $config->getPassword();
     }
 
     /**

--- a/src/Authentication/Managers/Google/AuthenticationOauthTokenManager.php
+++ b/src/Authentication/Managers/Google/AuthenticationOauthTokenManager.php
@@ -21,7 +21,7 @@ class AuthenticationOauthTokenManager extends Manager {
     {
         parent::__construct($config);
 
-        if ($config->getOauthToken() instanceof AccessToken) {
+        if ($config instanceof AccessToken) {
             $this->setAccessToken($config);
         } else {
             $this->token = $config->getOauthToken();

--- a/src/Authentication/Managers/Google/AuthenticationOauthTokenManager.php
+++ b/src/Authentication/Managers/Google/AuthenticationOauthTokenManager.php
@@ -15,14 +15,16 @@ class AuthenticationOauthTokenManager extends Manager {
     /**
      * AuthenticationOauthTokenManager constructor.
      *
-     * @param AccessToken|string $token
+     * @param $config
      */
-    public function __construct($token)
+    public function __construct($config)
     {
-        if ($token instanceof AccessToken) {
-            $this->setAccessToken($token);
+        parent::__construct($config);
+
+        if ($config->getOauthToken() instanceof AccessToken) {
+            $this->setAccessToken($config);
         } else {
-            $this->token = $token;
+            $this->token = $config->getOauthToken();
         }
     }
 

--- a/src/Authentication/Managers/Google/AuthenticationRefreshTokenManager.php
+++ b/src/Authentication/Managers/Google/AuthenticationRefreshTokenManager.php
@@ -16,11 +16,13 @@ class AuthenticationRefreshTokenManager extends Manager {
     /**
      * AuthenticationOauthTokenManager constructor.
      *
-     * @param string $token
+     * @param $config
      */
-    public function __construct($token)
+    public function __construct($config)
     {
-        $this->token = $token;
+        parent::__construct($config);
+
+        $this->token = $config->getRefreshToken();
     }
 
     /**

--- a/src/Authentication/Managers/PTC/AuthenticationCredentialsManager.php
+++ b/src/Authentication/Managers/PTC/AuthenticationCredentialsManager.php
@@ -22,13 +22,14 @@ class AuthenticationCredentialsManager extends Manager {
     /**
      * AuthenticationCodeManager constructor.
      *
-     * @param string $username
-     * @param string $password
+     * @param $config
      */
-    public function __construct($username, $password)
+    public function __construct($config)
     {
-        $this->username = $username;
-        $this->password = $password;
+        parent::__construct($config);
+
+        $this->username = $config->getUser();
+        $this->password = $config->getPassword();
     }
 
     /**

--- a/src/Authentication/Managers/PTC/AuthenticationOauthTokenManager.php
+++ b/src/Authentication/Managers/PTC/AuthenticationOauthTokenManager.php
@@ -15,11 +15,13 @@ class AuthenticationOauthTokenManager extends Manager
     /**
      * AuthenticationOauthTokenManager constructor.
      *
-     * @param AccessToken $token
+     * @param $config
      */
-    public function __construct(AccessToken $token)
+    public function __construct($config)
     {
-        $this->setAccessToken($token);
+        parent::__construct($config);
+
+        $this->setAccessToken($config);
     }
 
     public function getAccessToken()

--- a/src/Kernels/ApplicationKernel.php
+++ b/src/Kernels/ApplicationKernel.php
@@ -11,11 +11,6 @@ use NicklasW\PkmGoApi\Providers\RequestHandlerServiceProvider;
 class ApplicationKernel extends Kernel {
 
     /**
-     * @var AuthenticationManager
-     */
-    protected $manager;
-
-    /**
      * @var double
      */
     protected $latitude = 0;
@@ -33,9 +28,8 @@ class ApplicationKernel extends Kernel {
      */
     public function __construct($manager, $environmentFilePath = null)
     {
-        $this->manager = $manager;
+        parent::__construct($manager, $environmentFilePath);
 
-        parent::__construct($environmentFilePath);
     }
 
     /**

--- a/src/Kernels/Kernel.php
+++ b/src/Kernels/Kernel.php
@@ -20,6 +20,11 @@ use XStatic\ProxyManager;
 class Kernel implements ContainerInterface {
 
     /**
+     * @var AuthenticationManager
+     */
+    protected $manager;
+
+    /**
      * @var Container
      */
     protected $container;
@@ -44,9 +49,11 @@ class Kernel implements ContainerInterface {
      *
      * @param string|null $environmentFilePath
      */
-    public function __construct($environmentFilePath = null)
+    public function __construct($manager, $environmentFilePath = null)
     {
         $this->environmentFilePath = $environmentFilePath;
+
+        $this->manager = $manager;
 
         // Initialize the container
         $this->initializeContainer();

--- a/src/Kernels/Kernel.php
+++ b/src/Kernels/Kernel.php
@@ -11,6 +11,7 @@ use Monolog\Formatter\LineFormatter;
 use Monolog\Handler\NullHandler;
 use Monolog\Handler\StreamHandler;
 use Monolog\Logger;
+use NicklasW\PkmGoApi\Authentication\Config\AccessTokenConfig;
 use NicklasW\PkmGoApi\Config\Config;
 use NicklasW\PkmGoApi\Providers\ServiceProvider;
 use Psr\Log\LoggerInterface;
@@ -133,9 +134,24 @@ class Kernel implements ContainerInterface {
      */
     protected function loadEnvironmentVariables()
     {
+
+
+
         // Check if the environment file path is defined
         if ($this->environmentFilePath === null) {
-            return;
+
+            $config = $this->manager->getConfig();
+
+            if (($config instanceof Config || $config instanceof AccessTokenConfig) && $config->getEnvFilePath() !== null) {
+
+                $this->environmentFilePath = $config->getEnvFilePath();
+
+            } else {
+
+                return;
+
+            }
+
         }
 
         // Initialize the environment instance


### PR DESCRIPTION
Since we pass a Config instance into the Manager Factory, maybe it just makes sense to save the config information used to instantiate the manager.

This may allow us to define more things in the config object and access it later on from the manager instance using `getConfig()` method.

An example is the implementation for default .env path to where the app should look for the .env path if there is no path explicitly passed to the `ApplicationKernel`.

This will also answer the question `The configuration for the .env file path goes to the ApplicationKernel constructor while the configuration for the user credentials goes to the Config Object. But why? Shouldn't them be kept in a single place? `.

-------------------------------------------------------------------------------------

These commits also include implementation for default .env location.
If the user doesn't specify any path to where the app will look for the .env file, 
the app will attempt to look for it on the parent directories (up to 4 levels).
This is really helpful if you are using a framework like laravel and already have an `.env` file at the base path.
If no `.env` file is found any of the parent directories, it will not be loaded.

For backward compatibility, the user can still pass a second argument to the `ApplicationKernel` constructor to specify the env file location. (_check the `examples/AuthenticationExample.php`_) 

#111