### PR TITLE
Randomized RequestEnvelope::uk12 (ms_since_last_locationfix)

### DIFF
--- a/src/Handlers/RequestHandler.php
+++ b/src/Handlers/RequestHandler.php
@@ -220,7 +220,7 @@ class RequestHandler
 
         // Sets the request id
         $requestEnvelope->setRequestId($this->requestId());
-        $requestEnvelope->setUnknown12(989);
+        $requestEnvelope->setUnknown12(rand(901, 999));
 
         // Sets the location
         $requestEnvelope->setLatitude($this->application->getLocation()->getLatitude());


### PR DESCRIPTION
The upstream repo of the protos got quite a big update today, one of the changes was renaming `RequestEnvelope::unknown12` to `ms_since_last_locationfix` (https://github.com/AeonLucid/POGOProtos/commit/e9b4e769becf525374732d9ce4cd25e682f73cd3#diff-05fd34d99e02cbcf76d2626a0b9132e7R22).

Therefore I suggest randomizing the value a bit.

*`rand` is an insecure random generator, but I don't think it matters that much in this use-case.*