### PR TITLE
Increased minimum-version of Guzzle to fix a BC-problem

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     "require": {
         "php": ">=5.6",
         "paquettg/php-html-parser": "1.7",
-        "guzzlehttp/guzzle": "~6.0",
+        "guzzlehttp/guzzle": "^6.2.1",
         "jeremeamia/xstatic": "^1.0",
         "php-di/php-di": "^5.3",
         "phpseclib/phpseclib": "^2.0",


### PR DESCRIPTION
Implemented methods of [ClientProxy](https://github.com/NicklasWallgren/PokemonGoAPI-PHP/blob/4e1a5c3f3ac004f3f4494f346aeca4282b487001/src/Clients/Proxies/ClientProxy.php) did not match the declaration in the [ClientInterface](https://github.com/guzzle/guzzle/blob/master/src/ClientInterface.php) on versions before [6.2.1](https://github.com/guzzle/guzzle/releases/tag/6.2.1). Reported in #143.