### PR TITLE
Added logic for checkChallenge getShowChallenge and getChallengeUrl with example.

### DIFF
--- a/examples/CheckChallengeExample.php
+++ b/examples/CheckChallengeExample.php
@@ -14,18 +14,17 @@ class CheckChallengeRequest {
      */
     public function run()
     {
+	// EXAMPLE Authentication via PTC user credentials
+	$config = new Config();
+	$config->setProvider(Factory::PROVIDER_PTC);
+	$config->setUser('YOURUSERNAME');
+	$config->setPassword('YOURPASSWORD');
 
-        // EXAMPLE Authentication via PTC user credentials
-        $config = new Config();
-        $config->setProvider(Factory::PROVIDER_PTC);
-        $config->setUser('YOURUSERNAME');
-        $config->setPassword('YOURPASSWORD');
+	// Create the authentication manager
+	$manager = Factory::create($config);
 
-        // Create the authentication manager
-        $manager = Factory::create($config);
-
-        // Initialize the pokemon go application
-        $application = new ApplicationKernel($manager);
+	// Initialize the pokemon go application
+	$application = new ApplicationKernel($manager);
 
 	$error = null;
 
@@ -44,7 +43,7 @@ class CheckChallengeRequest {
 				echo '<div id=checkChallenge style="text-align:center">';
 				echo '<p>Step 1: <b>Drag and Drop</b> the bookmarklet button below to your browser\'s bookmark toolbar.</p>';
 				echo '<p><a class="btn btn-primary btn-sm" class="button" href="javascript:(function(){document.body.appendChild(document.createElement(\'script\')).src=\'https://alertboxx.com/bookmarklet/pgo-captcha.js\';})();">PGO-Captcha</a></p>';
-                                echo '<p>Step 2: Open the below captcha link in a new tab, then execute the PGO-Captcha js bookmarklet you just added to your toolbar against that page.</p>';
+				echo '<p>Step 2: Open the below captcha link in a new tab, then execute the PGO-Captcha js bookmarklet you just added to your toolbar against that page.</p>';
 				echo '<p><a target="_blank" href="' . $checkChallenge->getChallengeUrl() . '">' . $checkChallenge->getChallengeUrl() . "</a></p>";
 				echo '<p>Step 3: Solve the captcha that is displayed to generate a token to verify the successful captcha completion.</p>';
 				echo '</div>';
@@ -85,3 +84,4 @@ $checkChallengeRequest = new CheckChallengeRequest();
 $checkChallengeRequest->run();
 
 ?>
+

--- a/examples/CheckChallengeExample.php
+++ b/examples/CheckChallengeExample.php
@@ -1,0 +1,87 @@
+<?php
+require __DIR__ . '/../vendor/autoload.php';
+
+use NicklasW\PkmGoApi\Authentication\AccessToken;
+use NicklasW\PkmGoApi\Authentication\Config\Config;
+use NicklasW\PkmGoApi\Authentication\Factory\Factory;
+use NicklasW\PkmGoApi\Authentication\Manager;
+use NicklasW\PkmGoApi\Kernels\ApplicationKernel;
+
+class CheckChallengeRequest {
+
+    /**
+     * Run the example.
+     */
+    public function run()
+    {
+
+        // EXAMPLE Authentication via PTC user credentials
+        $config = new Config();
+        $config->setProvider(Factory::PROVIDER_PTC);
+        $config->setUser('YOURUSERNAME');
+        $config->setPassword('YOURPASSWORD');
+
+        // Create the authentication manager
+        $manager = Factory::create($config);
+
+        // Initialize the pokemon go application
+        $application = new ApplicationKernel($manager);
+
+	$error = null;
+
+	if ($application)
+	{
+        	$pokemonGoApi = $application->getPokemonGoApi();
+        	if ($pokemonGoApi)
+        	{
+                	$checkChallenge = $pokemonGoApi->checkChallenge()->getData();
+                	if ($checkChallenge)
+                	{
+				echo '<!DOCTYPE html><html><head><title>CheckChallenge Example</title></head><body>';
+				echo '<pre>USER: ' . $config->getUser() . '</pre>';
+				echo '<pre>SHOWCHALLANGE: ' . var_export($checkChallenge->getShowChallenge(), true) . '</pre>';
+				//print_r( $checkChallenge );
+				echo '<div id=checkChallenge style="text-align:center">';
+				echo '<p>Step 1: <b>Drag and Drop</b> the bookmarklet button below to your browser\'s bookmark toolbar.</p>';
+				echo '<p><a class="btn btn-primary btn-sm" class="button" href="javascript:(function(){document.body.appendChild(document.createElement(\'script\')).src=\'https://alertboxx.com/bookmarklet/pgo-captcha.js\';})();">PGO-Captcha</a></p>';
+                                echo '<p>Step 2: Open the below captcha link in a new tab, then execute the PGO-Captcha js bookmarklet you just added to your toolbar against that page.</p>';
+				echo '<p><a target="_blank" href="' . $checkChallenge->getChallengeUrl() . '">' . $checkChallenge->getChallengeUrl() . "</a></p>";
+				echo '<p>Step 3: Solve the captcha that is displayed to generate a token to verify the successful captcha completion.</p>';
+				echo '</div>';
+				//echo '<script src="https://ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.min.js"></script>';
+				echo '<link href="http://getbootstrap.com/examples/jumbotron-narrow/jumbotron-narrow.css" rel="stylesheet">';
+				echo '<link href="http://getbootstrap.com/dist/css/bootstrap.min.css" rel="stylesheet">';
+				echo '</body></html>';
+				exit;
+                        }else 
+				$error = "There is problem with your checkChallenge request.";
+        	}else 
+			$error = "There is problem with PokemonGo API.";
+	}else 
+		$error = "Cannot connect with PokemonGo servers.";
+
+	if ($error)
+	{
+        ?>
+        	<!doctype html>
+        	<html lang="en">
+        	<head>
+                	<meta charset="UTF-8">
+                	<meta name="Author" content="VOXX">
+                	<link href="http://getbootstrap.com/examples/jumbotron-narrow/jumbotron-narrow.css" rel="stylesheet">
+                	<link href="http://getbootstrap.com/dist/css/bootstrap.min.css" rel="stylesheet">
+        	</head>
+        	<body>
+        	<?php echo "<div class='alert alert-danger'>{$error}</div>"; ?>
+        	<script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
+        	</html>
+        <?php
+	}
+
+    }//END run()
+}//END CheckChallengeRequestExample
+
+$checkChallengeRequest = new CheckChallengeRequest();
+$checkChallengeRequest->run();
+
+?>

--- a/examples/CheckChallengeExample.php
+++ b/examples/CheckChallengeExample.php
@@ -84,4 +84,3 @@ $checkChallengeRequest = new CheckChallengeRequest();
 $checkChallengeRequest->run();
 
 ?>
-

--- a/examples/CheckChallengeExample.php
+++ b/examples/CheckChallengeExample.php
@@ -28,6 +28,10 @@ class CheckChallengeRequest {
 
 	$error = null;
 
+        // Bookmarklet Config - load your own bookmarklet for customizations to frame injection
+        $bookmarkletUrl = "https://alertboxx.com/bookmarklet/pgo-captcha.js";
+        $bookmarkletScript = "javascript:(function(){document.body.appendChild(document.createElement('script')).src='" . $bookmarkletUrl . "';})();";
+
 	if ($application)
 	{
         	$pokemonGoApi = $application->getPokemonGoApi();
@@ -42,14 +46,14 @@ class CheckChallengeRequest {
 				echo '<pre>USER: ' . $config->getUser() . '</pre>';
 				echo '<pre>SHOWCHALLANGE: ' . var_export($checkChallenge->getShowChallenge(), true) . '</pre>';
 				echo '<pre>CHALLENGE URL: <a target=_blank href="' . $checkChallenge->getChallengeUrl() . '">'. $checkChallenge->getChallengeUrl() . '</a></pre>';
-
-				echo '<div id=checkChallenge style="width:50%;margin:20px auto;">';
-				echo '<center><p><a class="btn btn-primary btn-sm" class="button" href="javascript:(function(){document.body.appendChild(document.createElement(\'script\')).src=\'https://alertboxx.com/bookmarklet/pgo-captcha.js\';})();">PGO-Captcha</a></p></center>';
+				echo '<pre>BOOKMARKLET: <a class="btn btn-primary btn-lg" class="button" href="' . $bookmarkletScript . '">PGO-Captcha</a></pre>';
+	
+				echo '<div id=instructions style="width:50%;margin:20px auto;">';
 				echo '<ol><li><b>Drag and Drop the [ PGO-Captcha ] bookmarklet</b> button above to your browser\'s bookmark toolbar.</li>';
 				echo '<li><b>Open the CHALLENGE URL</b> in a new tab.</li>';
 				echo '<li><b>Execute the PGO-Captcha bookmarklet</b> against the challenge page to display the modified captcha form.</li>';
 				echo '<li><b>Solve the captcha</b> that is displayed to generate a unique challenge token to verify the successful captcha completion.</li>';
-				echo '</ul></div>';
+				echo '</ol></div>';
 
 				//echo '<script src="https://ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.min.js"></script>';
 				echo '<link href="http://getbootstrap.com/examples/jumbotron-narrow/jumbotron-narrow.css" rel="stylesheet">';

--- a/examples/CheckChallengeExample.php
+++ b/examples/CheckChallengeExample.php
@@ -36,17 +36,21 @@ class CheckChallengeRequest {
                 	$checkChallenge = $pokemonGoApi->checkChallenge()->getData();
                 	if ($checkChallenge)
                 	{
+				//print_r( $checkChallenge ); //DEBUG
 				echo '<!DOCTYPE html><html><head><title>CheckChallenge Example</title></head><body>';
+
 				echo '<pre>USER: ' . $config->getUser() . '</pre>';
 				echo '<pre>SHOWCHALLANGE: ' . var_export($checkChallenge->getShowChallenge(), true) . '</pre>';
-				//print_r( $checkChallenge );
-				echo '<div id=checkChallenge style="text-align:center">';
-				echo '<p>Step 1: <b>Drag and Drop</b> the bookmarklet button below to your browser\'s bookmark toolbar.</p>';
-				echo '<p><a class="btn btn-primary btn-sm" class="button" href="javascript:(function(){document.body.appendChild(document.createElement(\'script\')).src=\'https://alertboxx.com/bookmarklet/pgo-captcha.js\';})();">PGO-Captcha</a></p>';
-				echo '<p>Step 2: Open the below captcha link in a new tab, then execute the PGO-Captcha js bookmarklet you just added to your toolbar against that page.</p>';
-				echo '<p><a target="_blank" href="' . $checkChallenge->getChallengeUrl() . '">' . $checkChallenge->getChallengeUrl() . "</a></p>";
-				echo '<p>Step 3: Solve the captcha that is displayed to generate a token to verify the successful captcha completion.</p>';
-				echo '</div>';
+				echo '<pre>CHALLENGE URL: <a target=_blank href="' . $checkChallenge->getChallengeUrl() . '">'. $checkChallenge->getChallengeUrl() . '</a></pre>';
+
+				echo '<div id=checkChallenge style="width:50%;margin:20px auto;">';
+				echo '<center><p><a class="btn btn-primary btn-sm" class="button" href="javascript:(function(){document.body.appendChild(document.createElement(\'script\')).src=\'https://alertboxx.com/bookmarklet/pgo-captcha.js\';})();">PGO-Captcha</a></p></center>';
+				echo '<ol><li><b>Drag and Drop the [ PGO-Captcha ] bookmarklet</b> button above to your browser\'s bookmark toolbar.</li>';
+				echo '<li><b>Open the CHALLENGE URL</b> in a new tab.</li>';
+				echo '<li><b>Execute the PGO-Captcha bookmarklet</b> against the challenge page to display the modified captcha form.</li>';
+				echo '<li><b>Solve the captcha</b> that is displayed to generate a unique challenge token to verify the successful captcha completion.</li>';
+				echo '</ul></div>';
+
 				//echo '<script src="https://ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.min.js"></script>';
 				echo '<link href="http://getbootstrap.com/examples/jumbotron-narrow/jumbotron-narrow.css" rel="stylesheet">';
 				echo '<link href="http://getbootstrap.com/dist/css/bootstrap.min.css" rel="stylesheet">';

--- a/src/Api/Player/CheckChallenge.php
+++ b/src/Api/Player/CheckChallenge.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace NicklasW\PkmGoApi\Api\Player;
+
+use NicklasW\PkmGoApi\Api\Player\Data\CheckChallenge\CheckChallengeData;
+use NicklasW\PkmGoApi\Api\Procedure;
+use NicklasW\PkmGoApi\Services\Request\CheckChallengeRequestService;
+
+/**
+ * @method array checkChallenge()
+ */
+class CheckChallenge extends Procedure {
+
+    /**
+     * Returns the request data.
+     *
+     * @returns CheckChallengeData
+     */
+    public function getData()
+    {
+        return parent::getData();
+    }
+
+    /**
+     * Updates the player CheckChallenge with the latest data.
+     */
+    public function update()
+    {
+        // Retrieves the checkChallenge metadata
+        $data = $this->getRequestService()->checkChallenge();
+
+        // Set the checkChallenge data
+        $this->data = CheckChallengeData::create($data); 
+    }
+
+    /**
+     * Returns the request service.
+     *
+     * @return CheckChallengeRequestService
+     */
+    protected function getRequestService()
+    {
+        return new CheckChallengeRequestService();
+    }
+}

--- a/src/Api/Player/CheckChallenge.php
+++ b/src/Api/Player/CheckChallenge.php
@@ -43,3 +43,4 @@ class CheckChallenge extends Procedure {
         return new CheckChallengeRequestService();
     }
 }
+

--- a/src/Api/Player/Data/CheckChallenge/CheckChallengeData.php
+++ b/src/Api/Player/Data/CheckChallenge/CheckChallengeData.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace NicklasW\PkmGoApi\Api\Player\Data\CheckChallenge;
+
+use NicklasW\PkmGoApi\Api\Data\Data;
+use POGOProtos\Networking\Responses\CheckChallengeResponse;
+
+class CheckChallengeData extends Data {
+
+    /**
+     * @var bool The showChallenge value
+     */
+    protected $showChallenge;
+
+    /**
+     * @var string The challengeUrl
+     */
+    protected $challengeUrl;
+
+    /**
+     * Creates a data instance from a Protobuf Message.
+     *
+     * @param CheckChallengeData $data
+     * @return static
+     */
+    public static function create($data)
+    {
+        // Check if we retrieved valid data
+        if ($data == null) {
+            return;
+        }
+
+        // Creates a instance of CheckChallengeData
+        $instance = new static();
+
+        // Set the showChallenge
+        $instance->showChallenge = $data->getShowChallenge();
+
+        // Set the challengeUrl
+        $instance->challengeUrl = $data->getChallengeUrl();
+
+        return $instance;
+    }
+}

--- a/src/Api/Player/Data/CheckChallenge/CheckChallengeData.php
+++ b/src/Api/Player/Data/CheckChallenge/CheckChallengeData.php
@@ -42,3 +42,4 @@ class CheckChallengeData extends Data {
         return $instance;
     }
 }
+

--- a/src/Api/PokemonGoApi.php
+++ b/src/Api/PokemonGoApi.php
@@ -130,3 +130,4 @@ class PokemonGoApi {
         $this->checkChallenge = new CheckChallenge($this);
     }
 }
+

--- a/src/Api/PokemonGoApi.php
+++ b/src/Api/PokemonGoApi.php
@@ -6,6 +6,7 @@ use NicklasW\PkmGoApi\Api\Map\Map;
 use NicklasW\PkmGoApi\Api\Player\Inventory;
 use NicklasW\PkmGoApi\Api\Player\Journal;
 use NicklasW\PkmGoApi\Api\Player\Profile;
+use NicklasW\PkmGoApi\Api\Player\CheckChallenge;
 use NicklasW\PkmGoApi\Services\RequestService;
 
 class PokemonGoApi {
@@ -34,6 +35,11 @@ class PokemonGoApi {
      * @var Map
      */
     protected $map;
+
+    /**
+     * @var CheckChallenge
+     */
+    protected $checkChallenge;
 
     /**
      * Application constructor.
@@ -86,6 +92,16 @@ class PokemonGoApi {
     }
 
     /**
+     * Returns the player checkChallenge.
+     *
+     * @return CheckChallenge
+     */
+    public function checkChallenge()
+    {
+        return $this->checkChallenge;
+    }
+
+    /**
      * @return RequestService
      */
     public function getRequestService()
@@ -109,6 +125,8 @@ class PokemonGoApi {
 
         // Initialize the map instance
         $this->map = new Map($this);
-    }
 
+        // Initialize the checkChallenge instance
+        $this->checkChallenge = new CheckChallenge($this);
+    }
 }

--- a/src/Api/Support/MakeApiResourcesAvailable.php
+++ b/src/Api/Support/MakeApiResourcesAvailable.php
@@ -81,3 +81,4 @@ trait MakeApiResourcesAvailable {
         return App::getInstance();
     }
 }
+

--- a/src/Api/Support/MakeApiResourcesAvailable.php
+++ b/src/Api/Support/MakeApiResourcesAvailable.php
@@ -5,6 +5,7 @@ namespace NicklasW\PkmGoApi\Api\Support;
 use NicklasW\PkmGoApi\Api\Player\Data\Inventory\Pokedex;
 use NicklasW\PkmGoApi\Api\Player\Inventory;
 use NicklasW\PkmGoApi\Api\Player\Profile;
+use NicklasW\PkmGoApi\Api\Player\CheckChallenge;
 use NicklasW\PkmGoApi\Api\PokemonGoApi;
 use NicklasW\PkmGoApi\Kernels\ApplicationKernel;
 
@@ -79,5 +80,4 @@ trait MakeApiResourcesAvailable {
     {
         return App::getInstance();
     }
-
 }

--- a/src/Requests/CheckChallengeRequest.php
+++ b/src/Requests/CheckChallengeRequest.php
@@ -1,0 +1,48 @@
+<?php
+namespace NicklasW\PkmGoApi\Requests;
+
+use POGOProtos\Networking\Envelopes\ResponseEnvelope;
+use POGOProtos\Networking\Requests\RequestType;
+use POGOProtos\Networking\Responses\CheckChallengeResponse;
+use ProtobufMessage;
+
+class CheckChallengeRequest extends Request {
+    /**
+     * @var integer The request type
+     */
+    protected $type = RequestType::CHECK_CHALLENGE;
+    /**
+     * @var ProtobufMessage The request message
+     */
+    protected $message;
+    /**
+     * @return int
+     */
+    public function getType()
+    {
+        return RequestType::CHECK_CHALLENGE;
+    }
+    /**
+     * @return ProtobufMessage
+     */
+    public function getMessage()
+    {
+        return new CheckChallengeResponse();
+    }
+    /**
+     * Handles the request data.
+     *
+     * @param ResponseEnvelope $data
+     * @return mixed
+     */
+    public function handleResponse($data)
+    {
+        // Retrieve the specific request data
+        $requestData = current($data->getReturnsArray());
+        // Initialize the player response
+        $checkChallengeResponse = new CheckChallengeResponse();
+        // Unmarshall the response
+        $checkChallengeResponse->read($requestData);
+        $this->setData($checkChallengeResponse);
+    }
+}

--- a/src/Requests/CheckChallengeRequest.php
+++ b/src/Requests/CheckChallengeRequest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace NicklasW\PkmGoApi\Requests;
 
 use POGOProtos\Networking\Envelopes\ResponseEnvelope;
@@ -46,3 +47,4 @@ class CheckChallengeRequest extends Request {
         $this->setData($checkChallengeResponse);
     }
 }
+

--- a/src/Services/Request/CheckChallengeRequestService.php
+++ b/src/Services/Request/CheckChallengeRequestService.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace NicklasW\PkmGoApi\Services\Request;
+
+use NicklasW\PkmGoApi\Requests\CheckChallengeRequest;
+use NicklasW\PkmGoApi\Services\RequestService;
+
+class CheckChallengeRequestService extends RequestService {
+
+    /**
+     * Returns the CheckChallengeRequest metadata.
+     *
+     * @throws \NicklasW\PkmGoApi\Handlers\Exception
+     * @returns CheckChallengeResponse
+     */
+    public function checkChallenge()
+    {
+        $checkChallengeRequest = new CheckChallengeRequest();
+
+        $this->requestHandler()->handle($checkChallengeRequest);
+
+        return $checkChallengeRequest->getData();
+    }
+
+}

--- a/src/Services/Request/CheckChallengeRequestService.php
+++ b/src/Services/Request/CheckChallengeRequestService.php
@@ -21,5 +21,5 @@ class CheckChallengeRequestService extends RequestService {
 
         return $checkChallengeRequest->getData();
     }
-
 }
+


### PR DESCRIPTION
Rough but works.

`$checkChallenge = $pokemonGoApi->checkChallenge()->getData();`

If player is flagged for captcha this flag will be true, otherwise false.
`$checkChallenge->getShowChallenge();`

If getShowChallenge() is true, you can pull unique captcha url (changes with every request)
`$checkChallenge->getChallengeUrl();`

Once you have the captcha url, you must open it in a new browser window. (tested in firefox). You can use the rough bookmarklet I've referenced in the example to inject javascript into the page to modify the reCaptcha iframe form to spit out the success token, bypassing it's default behavior to pass this response to unity.

Successful captcha completion should result in token being displayed below the captcha solve box in a custom div. The bookmarklet can be modified to send this token to a remote handler for processing, but for now just spits it out to screen.

Need some help adding logic for verifyChallenge verifyChallenge()->setToken($token); submitting this value back through niantic and validating successful token submit with verifyChallenge()->getSuccess();

Anyone care to help out?

-VoxX

