### PR TITLE
Rough Exception Handling fixes for "unexpected error" and "invalid_grant" during authentication.

### DIFF
--- a/examples/CheckChallengeExample.php
+++ b/examples/CheckChallengeExample.php
@@ -39,7 +39,14 @@ class CheckChallengeRequest {
             // Ensure api and user are not empty
             if ($pogoApi && $config->getUser())
             {
-                $checkChallenge = $pogoApi->checkChallenge()->getData();
+                try {
+                    $checkChallenge = $pogoApi->checkChallenge()->getData();
+                } catch (Exception $e) {
+                    //DEBUG - 
+                    echo 'Caught exception code: ',  $e->getCode, ' - ', $e->getMessage(), "\n";
+                    exit;
+                }
+                
                 if ($checkChallenge)
                 {
                     // Convert showChallenge boolean to string equiv

--- a/examples/CheckChallengeExample.php
+++ b/examples/CheckChallengeExample.php
@@ -42,9 +42,12 @@ class CheckChallengeRequest {
                 try {
                     $checkChallenge = $pogoApi->checkChallenge()->getData();
                 } catch (Exception $e) {
-                    //DEBUG - 
-                    echo 'Caught exception code: ',  $e->getCode, ' - ', $e->getMessage(), "\n";
-                    exit;
+                    // DEBUG
+                    // 498 - invalid_grant in body response (missing token/expires values)
+                    // 503 - Oops! It seems that Pokemon.com has had an unexpected error.
+                    // 0   - default error code
+                    $error = 'ERROR ' . $e->getCode() . ': ' . $e->getMessage() . '\n';
+                    $checkChallenge = FALSE;
                 }
                 
                 if ($checkChallenge)
@@ -106,8 +109,8 @@ document.getElementsByTagName('head')[0].appendChild(script);
 </html>
 EOBODY;
                     exit;
-                }else
-                    $error = "There was a problem with your checkChallenge() request!";
+                }
+                
             }else
                 $error = "Failed to initialize the PokemonGo API! Did you forget to set your credentials?";
         }else

--- a/src/Authentication/Managers/PTC/AuthenticationCredentials/Parsers/TicketParser.php
+++ b/src/Authentication/Managers/PTC/AuthenticationCredentials/Parsers/TicketParser.php
@@ -45,8 +45,9 @@ class TicketParser extends Parser {
             if (sizeof($errors) > 0) {
                 Log::debug(sprintf('[#%s] Error messages in response. Errors: \'%s\'', __CLASS__,
                     print_r($errors, true)));
-
-                throw new AuthenticationException(current($errors));
+                // A code of 503 indicates a service unavailable or unexpected error response. 0 is default
+                $code = (strstr(implode($errors),"unexpected error")) ? 503 : 0;
+                throw new AuthenticationException(current($errors),$code);
             }
         }
 

--- a/src/Authentication/Managers/PTC/AuthenticationCredentials/Parsers/TokenParser.php
+++ b/src/Authentication/Managers/PTC/AuthenticationCredentials/Parsers/TokenParser.php
@@ -29,9 +29,9 @@ class TokenParser extends Parser {
         $content = $response->getBody();
         
         // Check if the response includes any error messages
-        if (array_key_exists('errors', $content)) {
+        if (array_key_exists('error', $content)) {
             // Retrieve the error messages
-            $errors = $content['errors'];
+            $errors = $content['error'];
 
             // Check if there are any available error messages
             if (sizeof($errors) > 0) {

--- a/src/Authentication/Managers/PTC/AuthenticationCredentials/Parsers/TokenParser.php
+++ b/src/Authentication/Managers/PTC/AuthenticationCredentials/Parsers/TokenParser.php
@@ -37,8 +37,9 @@ class TokenParser extends Parser {
             if (sizeof($errors) > 0) {
                 Log::debug(sprintf('[#%s] Error messages in response. Errors: \'%s\'', __CLASS__,
                     print_r($errors, true)));
-                // A code of 498 indicates an expired or otherwise invalid token.
-                throw new AuthenticationException(current($errors),498);
+                // A code of 498 indicates an expired or otherwise invalid token. 0 is default
+                $code = in_array("invalid_grant", $errors) ? 498 : 0;
+                throw new AuthenticationException(current($errors),$code);
             }
         }
 

--- a/src/Authentication/Managers/PTC/AuthenticationCredentials/Parsers/TokenParser.php
+++ b/src/Authentication/Managers/PTC/AuthenticationCredentials/Parsers/TokenParser.php
@@ -37,8 +37,8 @@ class TokenParser extends Parser {
             if (sizeof($errors) > 0) {
                 Log::debug(sprintf('[#%s] Error messages in response. Errors: \'%s\'', __CLASS__,
                     print_r($errors, true)));
-
-                throw new AuthenticationException(current($errors));
+                // A code of 498 indicates an expired or otherwise invalid token.
+                throw new AuthenticationException(current($errors),498);
             }
         }
 


### PR DESCRIPTION
This is a rough fix for handling intermittent exceptions that can occur when attempting to authenticate.

I've added some body match checks for "unexpected error" and "invalid_grant" in ticket/token parser to throw specific error codes so they can be caught/handled by apps using the api.

Code 498 is now thrown with invalid_grant body match in TokenParser.php error response
Code 503 is now thrown with unexpected error body match in TicketParser.php error response.

Preferably we'd attempt to re-auth when either of these two specific errors occur, but this at least adds the ability to catch and handle these particular error types.

I've added a rough implementation on CheckChallengeExample.php

-VoxX